### PR TITLE
fix: refreshToken을 서버 쿠키에 저장하도록 수정

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,19 +1,31 @@
-import { Controller, Post, Body, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Body, HttpException, HttpStatus, Res, Req } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/create-login.dto';
+import { Response, Request } from 'express';
 
 @Controller('api/v1/auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login')
-  async login(@Body() loginDto: LoginDto) {
+  async login(@Body() loginDto: LoginDto, @Res({ passthrough: true }) res: Response) {
     try {
-      const accessToken = await this.authService.login(loginDto);
+      const { accessToken, refreshToken } = await this.authService.login(loginDto);
+
+      // Refresh Token을 HttpOnly 쿠키에 저장
+      res.cookie('refreshToken', refreshToken, {
+        httpOnly: true,
+        secure: true, // HTTPS 환경에서만 동작
+        sameSite: 'strict', // CSRF 공격 방지
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 7일 (밀리초 단위)
+      });
+
+      console.log('Refresh Token set in cookie:', refreshToken);
+
       return {
         status: 200,
         message: '로그인이 성공적으로 완료되었습니다.',
-        accessToken,
+        accessToken, // Access Token은 응답으로 반환
       };
     } catch (error) {
       throw new HttpException(
@@ -28,13 +40,29 @@ export class AuthController {
   }
 
   @Post('refresh')
-  async refresh(@Body('refreshToken') refreshToken: string) {
+  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     try {
-      const newAccessToken = await this.authService.refresh(refreshToken);
+      const oldRefreshToken = req.cookies['refreshToken'];
+
+      if (!oldRefreshToken) {
+        throw new HttpException('Refresh Token이 없습니다.', HttpStatus.UNAUTHORIZED);
+      }
+
+      const { accessToken, refreshToken } = await this.authService.refresh(oldRefreshToken);
+
+      // 새로운 Refresh Token을 쿠키에 설정
+      res.cookie('refreshToken', refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        maxAge: 7 * 24 * 60 * 60 * 1000, // 7일
+        // TODO: 추후 도메인 설정해서 로컬/서버 환경 분리해주기
+      });
+
       return {
         status: 200,
-        message: '새로운 Access Token이 발급되었습니다.',
-        accessToken: newAccessToken,
+        message: '새로운 Access Token과 Refresh Token이 발급되었습니다.',
+        accessToken,
       };
     } catch (error) {
       throw new HttpException(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #18 

## 📝 작업 기간

> 1시간

## 📝 작업 내용

- 백엔드에서 프론트엔드로 바로 보내는 refreshToken을 보안을 위해 백엔드 서버 cookie에 담는 방식으로 수정
- 위 작업으로 redis에 refreshToken을 담지 못하는 issue 해결
